### PR TITLE
Fix parsing subnet with host bits set

### DIFF
--- a/dockerdebug/render.py
+++ b/dockerdebug/render.py
@@ -61,7 +61,9 @@ def container_name_and_label(
     global NODE_ID
     name = f'{container["name"]}_{short_uid()}'
 
-    network_subnet = ipaddress.IPv4Network(network["subnet"])
+    # strict here does not fail when host bits are set
+    # likely a windows thing
+    network_subnet = ipaddress.IPv4Network(network["subnet"], strict=False)
 
     ip_addresses = []
     for interface in container["interfaces"]:


### PR DESCRIPTION
After running this in a network with the subnet defined as: 169.254.169.254/24, the code would fail to parse. The `ipaddress.IPv4Network` by default runs in strict mode, which raises an exception if the host bits are set (which they are in this case - the correct subnet definition is `169.254.169.0/24`).

We parse in non-strict mode, which seems to zero out the host bits where the mask is/isn't applied.
