### PR TITLE
Allow for rendering network graphs with the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
             nmap \
             jq \
             openssl \
+            graphviz \
         && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # So we can identify ourselves later with probe mode

--- a/README.md
+++ b/README.md
@@ -122,6 +122,20 @@ dot -Tpng -o output.png output.dot
 open output.png
 ```
 
+If this doesn't work, you can generate the png in the container:
+
+```bash
+docker run --rm \
+    -v <path to topology.json>:/topology.json \
+    ghcr.io/localstack/localstack-docker-debug:main render \
+    -f /topology.json > out.dot
+docker run --rm \
+    -v $PWD/out.dot:/out.dot \
+    --entrypoint dot \
+    ghcr.io/localstack/localstack-docker-debug:main \
+    -Tpng /out.dot > out.png
+```
+
 ### Package installation
 
 1. Install `dot` (graphviz)


### PR DESCRIPTION
We include graphviz in the container, so that if the user is not able to render graphs on their system, they can use the docker container.
