### PR TITLE
Mount output dir for render command

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ docker run --rm \
     ghcr.io/localstack/localstack-docker-debug:main render \
     -f /topology.json > out.dot
 docker run --rm \
-    -v $PWD/out.dot:/out.dot \
+    -v $PWD:/out \
     --entrypoint dot \
     ghcr.io/localstack/localstack-docker-debug:main \
-    -Tpng /out.dot > out.png
+    -Tpng /out/out.dot -o /out/out.png
 ```
 
 ### Package installation


### PR DESCRIPTION
When running under windows, mounting the file or piping to stdout seems to corrupt the png file. This change
* mounts the local directory to read from and write to
* uses graphviz to render the png and write to the mounted directory, bypassing stdout
